### PR TITLE
Add CocoaPods installation method

### DIFF
--- a/ExponeaSDK.podspec
+++ b/ExponeaSDK.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name             = "ExponeaSDK"
+  s.version          = "1.0.0"
+  s.summary          = "Exponea SDK for iOS."
+  s.homepage         = "https://github.com/exponea/exponea-ios"
+  s.license          = { :type => "Copyright", :text => 'Lorem ipsum dolorem sit amet...' }
+  s.author           = { "Exponea" => "info@exponea.com" }
+  s.source           = { :http => "https://github.com/EskiMag/exponea-ios.git", :tag => '1.0.0' }
+
+  s.platform     = :ios, '8.0'
+  s.requires_arc = true
+
+  s.source_files        = ['ExponeaLibSDK/*.h', 'ExponeaLibSDK/*.m', 'ExponeaSDK/*.h', 'ExponeaSDK/*.m']
+  s.public_header_files = ['ExponeaLibSDK/*.h']
+
+  s.frameworks = 'Foundation'
+  s.library = 'sqlite3'
+  s.vendored_frameworks = "ExponeaSDK.framework"
+end


### PR DESCRIPTION
**We'll be able to use the ExponeaSDK in our projects through CocoaPods**

`s.source` would need to be changed to your repo URL and also you'll need to add `1.0.0` tag into your repo.
Than all your clients will need to do is add `pod 'ExponeaSDK', :git => 'https://github.com/exponea/exponea-ios.git', :tag => '1.0.0'` into their `Podfile` and then run `pod install` command

In Swift project, there's then `import ExponeaSDK` statement needed. I didn't try to use it in the Obj-C  project, but it should be similar.

Also, you'll probably want to change the License attribute in the podspec file.